### PR TITLE
Support unit testing autoloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .buildpath
 .project
 .idea
+
+vendor/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: tests
+tests:
+	vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license":           "MIT",
   "minimum-stability": "dev",
   "require":           {
-    "php": ">=5.6.0",
+    "php": ">=7.0",
     "packaged/thrift" : "0.10.0",
     "opentracing/opentracing" : "1.0.0-beta2"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,17 @@
   "description":       "php client for jaeger",
   "keywords":          ["jaeger","trace","opentracing"],
   "license":           "MIT",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
+  "config": {
+    "platform": {
+      "php": "5.6"
+    }
+  },
   "require":           {
-    "php": ">=7.0",
+    "php": ">=5.6",
     "packaged/thrift" : "0.10.0",
-    "opentracing/opentracing" : "1.0.0-beta2"
+    "opentracing/opentracing" : "1.0.0-beta2",
+    "phpunit/phpunit": "^5.7"
   },
   "authors": [
     {
@@ -15,7 +21,7 @@
       "email": "742161455@qq.com"
     }
   ],
-  "autoload":          {
+  "autoload": {
     "psr-4": {
       "Jaeger\\": "src\\Jaeger"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,38 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/|version|/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        cacheResult="false"
+        cacheTokens="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        printerClass="PHPUnit\TextUI\ResultPrinter"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        stopOnRisky="false"
+        testSuiteLoaderClass="PHPUnit\Runner\StandardTestSuiteLoader"
+        timeoutForSmallTests="1"
+        timeoutForMediumTests="10"
+        timeoutForLargeTests="60"
+        verbose="false"
+        bootstrap="./vendor/autoload.php">
+        <testsuites>
+            <testsuite name="jaeger-php">
+                <directory>./tests</directory>
+            </testsuite>
+        </testsuites>
+        <filter>
+            <whitelist>
+                <directory>./src</directory>
+            </whitelist>
+        </filter>
+</phpunit>
+
+

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,30 +1,27 @@
 <?php
 
-require_once '../../autoload.php';
+namespace tests;
 
 use Jaeger\Config;
 use OpenTracing\NoopTracer;
+use PHPUnit\Framework\TestCase;
 
-class TestConfig extends PHPUnit_Framework_TestCase
+final class TestConfig extends TestCase
 {
-
-    public function testSetDisabled(){
+    public function testSetDisabled()
+    {
         $config = Config::getInstance();
         $config->setDisabled(true);
 
         $this->assertTrue($config::$disabled == true);
     }
 
-
-    public function testNoopTracer(){
-
+    public function testNoopTracer()
+    {
         $config = Config::getInstance();
         $config->setDisabled(true);
         $trace = $config->initTrace('test');
 
         $this->assertTrue($trace instanceof NoopTracer);
     }
-
-
-
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,7 +6,7 @@ use Jaeger\Config;
 use OpenTracing\NoopTracer;
 use PHPUnit\Framework\TestCase;
 
-final class TestConfig extends TestCase
+final class ConfigTest extends TestCase
 {
     public function testSetDisabled()
     {

--- a/tests/JaegerTest.php
+++ b/tests/JaegerTest.php
@@ -1,17 +1,16 @@
 <?php
 
-require_once '../../autoload.php';
+use PHPUnit\Framework\TestCase;
 
 use Jaeger\Jaeger;
 use Jaeger\Reporter\RemoteReporter;
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Transport\TransportUdp;
 
-class TestJaeger extends PHPUnit_Framework_TestCase
+final class TestJaeger extends TestCase
 {
-
-    public function testGetEnvTags(){
-
+    public function testGetEnvTags()
+    {
         $tranSport = new TransportUdp();
         $reporter = new RemoteReporter($tranSport);
         $sampler = new ConstSampler();
@@ -21,5 +20,4 @@ class TestJaeger extends PHPUnit_Framework_TestCase
 
         $this->assertTrue(count($tags) > 0);
     }
-
 }

--- a/tests/JaegerTest.php
+++ b/tests/JaegerTest.php
@@ -7,7 +7,7 @@ use Jaeger\Reporter\RemoteReporter;
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Transport\TransportUdp;
 
-final class TestJaeger extends TestCase
+final class JaegerTest extends TestCase
 {
     public function testGetEnvTags()
     {

--- a/tests/JaegerTest.php
+++ b/tests/JaegerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace tests;
+
 use PHPUnit\Framework\TestCase;
 
 use Jaeger\Jaeger;

--- a/tests/SamplerTest.php
+++ b/tests/SamplerTest.php
@@ -1,19 +1,20 @@
 <?php
+namespace tests;
 
 use PHPUnit\Framework\TestCase;
-
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Sampler\ProbabilisticSampler;
 
 class SamplerTest extends TestCase
 {
-    public function testConstSampler(){
+    public function testConstSampler()
+    {
         $sample = new ConstSampler(true);
         $this->assertTrue($sample->IsSampled()  == true);
     }
 
-
-    public function testProbabilisticSampler(){
+    public function testProbabilisticSampler()
+    {
         $sample = new ProbabilisticSampler(0.0001);
         $this->assertTrue($sample->IsSampled() !== null);
     }

--- a/tests/SamplerTest.php
+++ b/tests/SamplerTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Sampler\ProbabilisticSampler;
 
-class TestSampler extends TestCase
+class SamplerTest extends TestCase
 {
     public function testConstSampler(){
         $sample = new ConstSampler(true);

--- a/tests/SamplerTest.php
+++ b/tests/SamplerTest.php
@@ -1,13 +1,12 @@
 <?php
 
-require_once '../../autoload.php';
+use PHPUnit\Framework\TestCase;
 
 use Jaeger\Sampler\ConstSampler;
 use Jaeger\Sampler\ProbabilisticSampler;
 
-class TestSampler extends PHPUnit_Framework_TestCase
+class TestSampler extends TestCase
 {
-
     public function testConstSampler(){
         $sample = new ConstSampler(true);
         $this->assertTrue($sample->IsSampled()  == true);

--- a/tests/TestSpan.php
+++ b/tests/TestSpan.php
@@ -1,30 +1,28 @@
 <?php
 
-require_once '../../autoload.php';
+
 
 use OpenTracing\NoopSpanContext;
 use Jaeger\Span;
+use PHPUnit\Framework\TestCase;
 
-class TestSpan extends PHPUnit_Framework_TestCase
+class TestSpan extends TestCase
 {
-
     public function testOverwriteOperationName(){
-        $span = new Span('test1', new NoopSpanContext());
+        $span = new Span('test1', new NoopSpanContext(), []);
         $span->overwriteOperationName('test2');
         $this->assertTrue($span->getOperationName() == 'test2');
     }
 
-
     public function testAddTags(){
-        $span = new Span('test1', new NoopSpanContext());
-        $span->addTags(['test' => 'test']);
+        $span = new Span('test1', new NoopSpanContext(), []);
+        $span->setTags(['test' => 'test']);
         $this->assertTrue((isset($span->tags['test']) && $span->tags['test'] == 'test'));
     }
 
-
     public function testFinish(){
-        $span = new Span('test1', new NoopSpanContext());
-        $span->addTags(['test' => 'test']);
+        $span = new Span('test1', new NoopSpanContext(), []);
+        $span->setTags(['test' => 'test']);
         $span->finish();
         $this->assertTrue(!empty($span->finishTime) && !empty($span->duration));
     }


### PR DESCRIPTION
@jukylin Hey master! 

I've improved your unit tests, even if some of them are failing:
- Support class autoloading for unit tests
- Installed phpunit 8 and added to require-dev (available only when developing). I also changed some unit tests to extend the new class from PhpUnit 8.
- Force support for PHP 7.0 ([that reached already end of life on Jan 10 2019](https://www.php.net/eol.php))
- Also added a Makefile. To run the tests you just have to do `make tests`. 

At my company, we have support for opentracing in NodeJS and Go services but not with PHP. And I think we can use this library and improve it.