### PR TITLE
Fix ScopeManager to handle nested scopes

### DIFF
--- a/src/Jaeger/ScopeManager.php
+++ b/src/Jaeger/ScopeManager.php
@@ -48,10 +48,9 @@ class ScopeManager implements \OpenTracing\ScopeManager{
 
         for ($i = 0; $i < $scopeLength; $i++) {
             if ($scope === $this->scopes[$i]) {
-                unset($this->scopes[$i]);
+                array_splice($this->scopes, $i, 1);
             }
         }
-        sort($this->scopes);
 
         return true;
     }


### PR DESCRIPTION
The current implementation of ScopeManager results in an array with missing indices e.g.

[0 -> Scope, 2 -> Scope, 3 -> Scope] (missing index 1)

This leads to unpredictable results when iterating from 0 -> count($this->scopes).

Was that why `sort` was added to correct this? Unfortunately sort produces a reordering of scopes - see the test case `testDelActiveNestedScopes`