### PR TITLE
修复 startSpan 时 ref 只有 follows_from 的时候忽略了 parent context 的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 composer.lock
 vendor/*
+build

--- a/src/Jaeger/Jaeger.php
+++ b/src/Jaeger/Jaeger.php
@@ -210,9 +210,22 @@ class Jaeger implements Tracer{
     private function getParentSpanContext(StartSpanOptions $options)
     {
         $references = $options->getReferences();
+
+        $parentSpan = null;
+
         foreach ($references as $ref) {
+            $parentSpan = $ref->getContext();
             if ($ref->isType(Reference::CHILD_OF)) {
-                return $ref->getContext();
+                return $parentSpan;
+            }
+        }
+
+        if ($parentSpan) {
+            if (($parentSpan->isValid()
+                || (!$parentSpan->isTraceIdValid() && $parentSpan->debugId)
+                || count($parentSpan->baggage) > 0)
+            ) {
+                return $parentSpan;
             }
         }
 

--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -145,4 +145,20 @@ class SpanContext implements \OpenTracing\SpanContext{
     }
 
 
+    /**
+     * @return bool
+     */
+    public function isValid()
+    {
+        return $this->isTraceIdValid() && $this->spanId;
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function isTraceIdValid()
+    {
+        return $this->traceIdLow || $this->traceIdHigh;
+    }
 }


### PR DESCRIPTION
与 https://github.com/jaegertracing/jaeger-client-go/pull/313 这个问题类似