### PR TITLE
remove unused properties

### DIFF
--- a/src/Jaeger/Jaeger.php
+++ b/src/Jaeger/Jaeger.php
@@ -42,15 +42,9 @@ class Jaeger implements Tracer{
 
     public $process = null;
 
-    public $procesSize = 0;
-
     public $serverName = '';
 
-    public $bufferSize = '';
-
     public $processThrift = '';
-
-    public $spanThrifts = [];
 
     public $propagator = null;
 

--- a/src/Jaeger/Jaeger.php
+++ b/src/Jaeger/Jaeger.php
@@ -34,8 +34,6 @@ class Jaeger implements Tracer{
 
     private $scopeManager;
 
-    public static $handleProto = null;
-
     public $spans = [];
 
     public $tags = [];

--- a/src/Jaeger/Transport/TransportUdp.php
+++ b/src/Jaeger/Transport/TransportUdp.php
@@ -102,8 +102,6 @@ class TransportUdp implements Transport
                 continue;
             }
 
-            $jaeger->spanThrifts[] = $spanThrift;
-
             if ($this->bufferSize + $spanSize >= self::$maxSpanBytes) {
                 self::$batchs[] = [
                     'thriftProcess' => $jaeger->processThrift,


### PR DESCRIPTION
remove unused properties.
moreover `spanThrifts` unused, but `$jaeger->spanThrifts[] = $spanThrift;` can may cause memory leak in demonized php scripts.