### PR TITLE
fix working with baggage

### DIFF
--- a/src/Jaeger/Span.php
+++ b/src/Jaeger/Span.php
@@ -113,10 +113,10 @@ class Span implements \OpenTracing\Span{
 
     /**
      * @param string $key
-     * @return string
+     * @return string|null
      */
     public function getBaggageItem($key){
-        $this->spanContext->getBaggageItem($key);
+        return $this->spanContext->getBaggageItem($key);
     }
 
 

--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -54,7 +54,7 @@ class SpanContext implements \OpenTracing\SpanContext{
 
 
     public function getBaggageItem($key){
-        return isset($this->baggage[$key]) ? $this->baggage[$key] : false;
+        return isset($this->baggage[$key]) ? $this->baggage[$key] : null;
     }
 
 

--- a/tests/SpanContextTest.php
+++ b/tests/SpanContextTest.php
@@ -48,7 +48,7 @@ class SpanContextTest extends TestCase
         $this->assertTrue($res == $version);
 
         $service = $spanContext->getBaggageItem('service');
-        $this->assertTrue($service == false);
+        $this->assertNull($service);
     }
 
 

--- a/tests/SpanTest.php
+++ b/tests/SpanTest.php
@@ -15,6 +15,7 @@
 
 namespace tests;
 
+use Jaeger\SpanContext;
 use OpenTracing\NoopSpanContext;
 use Jaeger\Span;
 use PHPUnit\Framework\TestCase;
@@ -60,5 +61,17 @@ class SpanTest extends TestCase
         ];
         $span->log($logs);
         $this->assertTrue(count($span->logs) == 1);
+    }
+
+
+    public function testGetBaggageItem(){
+        $span = new Span('test', new SpanContext(0, 0, 0), []);
+        $span->addBaggageItem('version', '2.0.0');
+
+        $version =  $span->getBaggageItem('version');
+        $this->assertEquals('2.0.0', $version);
+
+        $service = $span->getBaggageItem('service');
+        $this->assertNull($service);
     }
 }


### PR DESCRIPTION
- `OpenTracing\SpanContext::getBaggageItem()` need to return `string|null`
- fix bug with `Jaeger\Span::getBaggageItem()` always return `null` 