### PR TITLE
Extract null span context

### DIFF
--- a/src/Jaeger/Jaeger.php
+++ b/src/Jaeger/Jaeger.php
@@ -16,6 +16,7 @@
 namespace Jaeger;
 
 use Jaeger\Sampler\Sampler;
+use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\SpanContext;
 use OpenTracing\Formats;
 use OpenTracing\Tracer;
@@ -44,6 +45,7 @@ class Jaeger implements Tracer{
 
     public $processThrift = '';
 
+    /** @var Propagator|null */
     public $propagator = null;
 
     public function __construct($serverName = '', Reporter $reporter, Sampler $sampler,
@@ -136,7 +138,7 @@ class Jaeger implements Tracer{
         if($format == Formats\TEXT_MAP){
             $this->propagator->inject($spanContext, $format, $carrier);
         }else{
-            throw new \Exception("not support format $format");
+            throw UnsupportedFormat::forFormat($format);
         }
     }
 
@@ -150,7 +152,7 @@ class Jaeger implements Tracer{
         if($format == Formats\TEXT_MAP){
             return $this->propagator->extract($format, $carrier);
         }else{
-            throw new \Exception("not support format $format");
+            throw UnsupportedFormat::forFormat($format);
         }
     }
 

--- a/src/Jaeger/Propagator/JaegerPropagator.php
+++ b/src/Jaeger/Propagator/JaegerPropagator.php
@@ -31,12 +31,22 @@ class JaegerPropagator implements Propagator{
 
 
     public function extract($format, $carrier){
-        $spanContext = new SpanContext(0, 0, 0, null, 0);
-        $emptyContextHash = $spanContext->getMD5();
-
+        $spanContext = null;
+        
         $carrier = array_change_key_case($carrier, CASE_LOWER);
 
         foreach ($carrier as $k => $v){
+            
+            if(!in_array($k, [Constants\Tracer_State_Header_Name,
+                Constants\Jaeger_Debug_Header, Constants\Jaeger_Baggage_Header]) &&
+                stripos($k, Constants\Trace_Baggage_Header_Prefix) === false){
+                continue;
+            }
+
+            if($spanContext === null){
+                $spanContext = new SpanContext(0, 0, 0, null, 0);
+            }
+            
             if(is_array($v)){
                 $v = urldecode(current($v));
             }else {
@@ -77,7 +87,7 @@ class JaegerPropagator implements Propagator{
         }
 
 
-        return $emptyContextHash === $spanContext->getMD5() ? null : $spanContext;
+        return $spanContext;
     }
 
 }

--- a/src/Jaeger/Propagator/JaegerPropagator.php
+++ b/src/Jaeger/Propagator/JaegerPropagator.php
@@ -30,13 +30,9 @@ class JaegerPropagator implements Propagator{
     }
 
 
-    /**
-     * 提取
-     * @param string $format
-     * @param $carrier
-     */
     public function extract($format, $carrier){
         $spanContext = new SpanContext(0, 0, 0, null, 0);
+        $emptyContextHash = $spanContext->getMD5();
 
         $carrier = array_change_key_case($carrier, CASE_LOWER);
 
@@ -81,7 +77,7 @@ class JaegerPropagator implements Propagator{
         }
 
 
-        return $spanContext;
+        return $emptyContextHash === $spanContext->getMD5() ? null : $spanContext;
     }
 
 }

--- a/src/Jaeger/Propagator/Propagator.php
+++ b/src/Jaeger/Propagator/Propagator.php
@@ -32,6 +32,7 @@ interface Propagator{
      * 提取
      * @param string $format
      * @param $carrier
+     * @return SpanContext|null
      */
     public function extract($format, $carrier);
 

--- a/src/Jaeger/Propagator/ZipkinPropagator.php
+++ b/src/Jaeger/Propagator/ZipkinPropagator.php
@@ -30,6 +30,7 @@ class ZipkinPropagator implements Propagator{
 
     public function extract($format, $carrier){
         $spanContext = new SpanContext(0, 0, 0, null, 0);
+        $emptyContextHash = $spanContext->getMD5();
         if(isset($carrier[Constants\X_B3_TRACEID]) && $carrier[Constants\X_B3_TRACEID]){
             $spanContext->traceIdToString($carrier[Constants\X_B3_TRACEID]);
         }
@@ -47,6 +48,6 @@ class ZipkinPropagator implements Propagator{
         }
 
 
-        return $spanContext;
+        return $emptyContextHash === $spanContext->getMD5() ? null : $spanContext;
     }
 }

--- a/src/Jaeger/Propagator/ZipkinPropagator.php
+++ b/src/Jaeger/Propagator/ZipkinPropagator.php
@@ -29,8 +29,19 @@ class ZipkinPropagator implements Propagator{
 
 
     public function extract($format, $carrier){
-        $spanContext = new SpanContext(0, 0, 0, null, 0);
-        $emptyContextHash = $spanContext->getMD5();
+        $spanContext = null;
+
+        foreach ($carrier as $k => $val) {
+            if (in_array($k, [Constants\X_B3_TRACEID,
+                Constants\X_B3_PARENT_SPANID, Constants\X_B3_SPANID, Constants\X_B3_SAMPLED])
+            ) {
+                if($spanContext === null){
+                    $spanContext = new SpanContext(0, 0, 0, null, 0);
+                }
+                continue;
+            }
+        }
+        
         if(isset($carrier[Constants\X_B3_TRACEID]) && $carrier[Constants\X_B3_TRACEID]){
             $spanContext->traceIdToString($carrier[Constants\X_B3_TRACEID]);
         }
@@ -48,6 +59,6 @@ class ZipkinPropagator implements Propagator{
         }
 
 
-        return $emptyContextHash === $spanContext->getMD5() ? null : $spanContext;
+        return $spanContext;
     }
 }

--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -161,4 +161,12 @@ class SpanContext implements \OpenTracing\SpanContext{
     {
         return $this->traceIdLow || $this->traceIdHigh;
     }
+
+    /**
+     * @return string
+     */
+    public function getMD5()
+    {
+        return md5(serialize($this));
+    }
 }

--- a/src/Jaeger/SpanContext.php
+++ b/src/Jaeger/SpanContext.php
@@ -161,12 +161,4 @@ class SpanContext implements \OpenTracing\SpanContext{
     {
         return $this->traceIdLow || $this->traceIdHigh;
     }
-
-    /**
-     * @return string
-     */
-    public function getMD5()
-    {
-        return md5(serialize($this));
-    }
 }

--- a/tests/JaegerTest.php
+++ b/tests/JaegerTest.php
@@ -82,7 +82,7 @@ class JaegerTest extends TestCase
         $Jaeger->setPropagator(new JaegerPropagator());
 
         $context = new SpanContext(1, 1, 1, null, 1);
-        $this->expectExceptionMessage('not support format http_headers');
+        $this->expectExceptionMessage('The format \'http_headers\' is not supported.');
 
         $Jaeger->inject($context, Formats\HTTP_HEADERS, $_SERVER);
     }
@@ -106,7 +106,7 @@ class JaegerTest extends TestCase
         $Jaeger->setPropagator(new JaegerPropagator());
 
         $_SERVER[strtoupper(Constants\Tracer_State_Header_Name)] = '1:1:1:1';
-        $this->expectExceptionMessage('not support format http_headers');
+        $this->expectExceptionMessage('The format \'http_headers\' is not supported.');
 
         $Jaeger->extract(Formats\HTTP_HEADERS, $_SERVER);
     }

--- a/tests/Propagator/JaegerPropagatorTest.php
+++ b/tests/Propagator/JaegerPropagatorTest.php
@@ -70,7 +70,7 @@ class JaegerPropagatorTest extends TestCase{
     public function testExtractDebugId(){
 
         $jaeger = new JaegerPropagator();
-        $carrier = [];
+        $carrier[Constants\Trace_Baggage_Header_Prefix . 'baggage'] = 2;
 
         $context = $jaeger->extract(Formats\TEXT_MAP, $carrier);
         $this->assertTrue($context->debugId == 0);
@@ -85,6 +85,7 @@ class JaegerPropagatorTest extends TestCase{
         $jaeger = new JaegerPropagator();
 
         $carrier[Constants\Trace_Baggage_Header_Prefix] = '2.0.0';
+        $carrier[Constants\Jaeger_Debug_Header] = true;
         $context = $jaeger->extract(Formats\TEXT_MAP, $carrier);
         $this->assertTrue($context->baggage == null);
 
@@ -113,6 +114,7 @@ class JaegerPropagatorTest extends TestCase{
         $carrier = [];
 
         $carrier[Constants\Jaeger_Baggage_Header] = 'version';
+        $carrier[Constants\Jaeger_Debug_Header] = true;
         $context = $jaeger->extract(Formats\TEXT_MAP, $carrier);
         $this->assertTrue($context->baggage == null);
     }

--- a/tests/Propagator/JaegerPropagatorTest.php
+++ b/tests/Propagator/JaegerPropagatorTest.php
@@ -148,4 +148,13 @@ class JaegerPropagatorTest extends TestCase{
         $this->assertTrue($context->spanId == 1562237095801441413);
         $this->assertTrue($context->flags == 1);
     }
+
+
+    public function testExtractReturnsNull(){
+        $jaeger = new JaegerPropagator();
+        $carrier = [];
+
+        $context = $jaeger->extract(Formats\TEXT_MAP, $carrier);
+        $this->assertNull($context);
+    }
 }

--- a/tests/Propagator/ZipkinPropagatorTest.php
+++ b/tests/Propagator/ZipkinPropagatorTest.php
@@ -92,4 +92,13 @@ class ZipkinPropagatorTest extends TestCase{
         $this->assertTrue($context->spanId == 1562289663898779811);
         $this->assertTrue($context->flags == 1);
     }
+
+
+    public function testExtractReturnsNull(){
+        $jaeger = new ZipkinPropagator();
+        $carrier = [];
+
+        $context = $jaeger->extract(Formats\TEXT_MAP, $carrier);
+        $this->assertNull($context);
+    }
 }


### PR DESCRIPTION
According to the [opentracing](https://github.com/opentracing/opentracing-php/blob/0c421ae732bbcf4765088ae3f212c20541b4c13f/src/OpenTracing/Tracer.php#L97) specification, `null` may be returned instead of a `SpanContext` by `Tracer->extract()`. This PR adds this behaviour and prevents ugly warnings in Jaeger, which complains about invalid span references:

![image](https://user-images.githubusercontent.com/1932623/71634998-da398600-2c20-11ea-90fb-4df7e9277a34.png)