### PR TITLE
fix: add exception when generated thrift string exceeds maximum allowed package siz

### DIFF
--- a/src/Jaeger/Thrift/AgentClient.php
+++ b/src/Jaeger/Thrift/AgentClient.php
@@ -15,6 +15,7 @@
 
 namespace Jaeger\Thrift;
 
+use Exception;
 use Thrift\Transport\TMemoryBuffer;
 use Thrift\Protocol\TCompactProtocol;
 use Thrift\Type\TMessageType;
@@ -26,6 +27,9 @@ class AgentClient
 
     public static $tptl = null;
 
+    /**
+     * @throws Exception
+     */
     public function buildThrift($batch)
     {
         $tran = new TMemoryBuffer();
@@ -41,6 +45,16 @@ class AgentClient
 
         $batchLen = $tran->available();
         $batchThriftStr = $tran->read(Constants\UDP_PACKET_MAX_LENGTH);
+
+        if ($batchLen !== strlen($batchThriftStr)) {
+            throw new Exception(
+                sprintf(
+                    'thrift string was longer than maximum allowed length: %d > %d',
+                    $batchLen,
+                    strlen($batchThriftStr)
+                )
+            );
+        }
 
         return ['len' => $batchLen, 'thriftStr' => $batchThriftStr];
     }

--- a/tests/Thrift/AgentClientTest.php
+++ b/tests/Thrift/AgentClientTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace tests\Thrift;
+
+use Exception;
+use Jaeger\Thrift\AgentClient;
+use PHPUnit\Framework\TestCase;
+
+class AgentClientTest extends TestCase
+{
+    /**
+     * @param int $spanCount
+     * @dataProvider provideSpanCount
+     * @throws Exception
+     */
+    public function testBuildThriftSuccess($spanCount)
+    {
+        $batch = $this->createBatchWithSpans($spanCount);
+
+        $subject = new AgentClient();
+        $result = $subject->buildThrift($batch);
+        self::assertSame($result['len'], strlen($result['thriftStr']));
+    }
+
+    public function provideSpanCount()
+    {
+        return [
+            [1],
+            [10],
+            [100],
+            [999]
+        ];
+    }
+
+    public function testBuildThriftFailsTooLong()
+    {
+        $batch = $this->createBatchWithSpans(1000);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/thrift string was longer than maximum allowed length/');
+
+        $subject = new AgentClient();
+        $subject->buildThrift($batch);
+    }
+
+    /**
+     * @param int $spanCount
+     * @return array
+     */
+    private function createBatchWithSpans($spanCount)
+    {
+        $batch = [
+            'thriftProcess' => [
+                'serverName' => 'some server name',
+                'tags' => [
+                    'peer.ipv4' => '0.0.0.0'
+                ]
+            ],
+            'thriftSpans' => []
+        ];
+
+        for ($i = 0; $i < $spanCount; $i++) {
+            $batch['thriftSpans'][] = [
+                'spanId' => '123456789',
+                'operationName' => 'operation name 123456789012',
+                'tags' => [
+                    'span.kind' => 'client'
+                ],
+                'traceIdLow' => '999012393582',
+                'traceIdHigh' => '12338923423',
+                'parentSpanId' => null,
+                'flags' => null,
+                'startTime' => time(),
+                'duration' => 5,
+                'references' => []
+            ];
+        }
+        return $batch;
+    }
+}


### PR DESCRIPTION
Hi,

when experimenting with very large traces, I encountered errors related to `socket_sendto`, which is fine:

    socket_sendto(): unable to write to socket [90]: Message too long

However, there is a small window from 65000 bytes to 65507 bytes, where packages are created and sent by this library, but discarded of Jaeger, because not the complete thrift payload fit into one package.

This PR adds an exception to cover those edge cases and a test for `AgentClient`. Feel free to ask questions and provide feedback for improvements. :)