### PR TITLE
Support custom startTime in spans

### DIFF
--- a/src/Jaeger/Jaeger.php
+++ b/src/Jaeger/Jaeger.php
@@ -109,7 +109,8 @@ class Jaeger implements Tracer{
             }
         }
 
-        $span = new Span($operationName, $spanContext, $options->getReferences());
+        $startTime = $options->getStartTime() ? intval($options->getStartTime() * 1000000) : null;
+        $span = new Span($operationName, $spanContext, $options->getReferences(), $startTime);
         if(!empty($options->getTags())) {
             foreach ($options->getTags() as $k => $tag) {
                 $span->setTag($k, $tag);

--- a/src/Jaeger/Span.php
+++ b/src/Jaeger/Span.php
@@ -36,9 +36,9 @@ class Span implements \OpenTracing\Span{
 
     public $references = [];
 
-    public function __construct($operationName, \OpenTracing\SpanContext $spanContext, $references){
+    public function __construct($operationName, \OpenTracing\SpanContext $spanContext, $references, $startTime = null){
         $this->operationName = $operationName;
-        $this->startTime = $this->microtimeToInt();
+        $this->startTime = $startTime == null ? $this->microtimeToInt() : $startTime;
         $this->spanContext = $spanContext;
         $this->references = $references;
     }

--- a/tests/JaegerTest.php
+++ b/tests/JaegerTest.php
@@ -114,7 +114,8 @@ class JaegerTest extends TestCase
 
     public function testStartSpan(){
         $Jaeger = $this->getJaeger();
-        $Jaeger->startSpan('test');
+        $span = $Jaeger->startSpan('test');
+        $this->assertNotEmpty($span->startTime);
         $this->assertNotEmpty($Jaeger->getSpans());
     }
 
@@ -155,6 +156,15 @@ class JaegerTest extends TestCase
         ]);
 
         $this->assertSame($childSpan->spanContext->traceIdLow, $rootSpan->spanContext->traceIdLow);
+    }
+
+
+    public function testStartSpanWithCustomStartTime()
+    {
+        $jaeger = $this->getJaeger();
+        $span = $jaeger->startSpan('test', ['start_time' => 1499355363.123456]);
+
+        $this->assertSame(1499355363123456, $span->startTime);
     }
 
 


### PR DESCRIPTION
This allows delayed span creation, since custom finish times are already supported.

Unlike other timestamps in the repo, the start_time is passed in seconds instead of microseconds https://github.com/opentracing/opentracing-php/blob/d27712246564cb38e2346c677a16801d70ed1da1/tests/OpenTracing/StartSpanOptionsTest.php#L64

Fixes #85 